### PR TITLE
Init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+
+
 <!-- markdownlint-disable -->
-<a href="https://cpco.io/homepage"><img src=".github/banner.png?raw=true" alt="Project Banner"/></a><br/>
+<a href="https://cpco.io/homepage"><img src="https://github.com/cloudposse-terraform-components/aws-eks-addon/blob/main/.github/banner.png?raw=true" alt="Project Banner"/></a><br/>
     <p align="right">
-<a href="https://github.com/cloudposse-terraform-components/template/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-terraform-components/template.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a></p>
+<a href="https://github.com/cloudposse-terraform-components/aws-eks-addon/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-terraform-components/aws-eks-addon.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a></p>
 <!-- markdownlint-restore -->
 
 <!--
@@ -25,38 +27,59 @@
 
 -->
 
-Description of this component
+This component is responsible for installing and managing addons for EKS clusters.
+
+You may want to use this component rather than `var.addons` with `eks/cluster` to deploy addons that require additional
+prerequisites or configuration before they can be installed. For example, if you need to install a priority class before
+installing an addon, you can use this component to install the priority class first.
 
 
----
-> [!NOTE]
-> This project is part of Cloud Posse's comprehensive ["SweetOps"](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=) approach towards DevOps.
-> <details><summary><strong>Learn More</strong></summary>
+> [!TIP]
+> #### 👽 Use Atmos with Terraform
+> Cloud Posse uses [`atmos`](https://atmos.tools) to easily orchestrate multiple environments using Terraform. <br/>
+> Works with [Github Actions](https://atmos.tools/integrations/github-actions/), [Atlantis](https://atmos.tools/integrations/atlantis), or [Spacelift](https://atmos.tools/integrations/spacelift).
 >
-> It's 100% Open Source and licensed under the [APACHE2](LICENSE).
->
+> <details>
+> <summary><strong>Watch demo of using Atmos with Terraform</strong></summary>
+> <img src="https://github.com/cloudposse/atmos/blob/main/docs/demo.gif?raw=true"/><br/>
+> <i>Example of running <a href="https://atmos.tools"><code>atmos</code></a> to manage infrastructure from our <a href="https://atmos.tools/quick-start/">Quick Start</a> tutorial.</i>
 > </details>
 
-<a href="https://cloudposse.com/readme/header/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_header_link"><img src="https://cloudposse.com/readme/header/img"/></a>
 
 
 
 
 ## Usage
 
+**Stack Level**: Regional
 
-
-**Stack Level**: Regional or Test47
-
-Here's an example snippet for how to use this component.
+For example, to install the CloudWatch Observability addon for EKS:
 
 ```yaml
 components:
   terraform:
-    foo:
+    # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Observability-EKS-addon.html
+    eks/addon/cloudwatch:
+      metadata:
+        component: eks/addon
       vars:
-        enabled: true
+        addon_name: amazon-cloudwatch-observability
+        addon_version: "v2.5.0-eksbuild.1"
+        kubernetes_namespace: amazon-cloudwatch # this namespace is defined by the addon
+        resolve_conflicts_on_create: OVERWRITE
+        resolve_conflicts_on_update: OVERWRITE
+        priority_class_enabled: true
+        additional_policy_arns:
+          - "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 ```
+
+> [!IMPORTANT]
+> In Cloud Posse's examples, we avoid pinning modules to specific versions to prevent discrepancies between the documentation
+> and the latest released versions. However, for your own projects, we strongly advise pinning each module to the exact version
+> you're using. This practice ensures the stability of your infrastructure. Additionally, we recommend implementing a systematic
+> approach for updating versions to avoid unexpected changes.
+
+
 
 
 
@@ -66,9 +89,7 @@ components:
 <!-- markdownlint-disable -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+No requirements.
 
 ## Providers
 
@@ -76,9 +97,7 @@ No providers.
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+No modules.
 
 ## Resources
 
@@ -86,32 +105,11 @@ No resources.
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
-| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
-| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
-| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
-| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
-| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+No inputs.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_mock"></a> [mock](#output\_mock) | Mock output example for the Cloud Posse Terraform component template |
+No outputs.
 <!-- markdownlint-restore -->
 
 
@@ -131,26 +129,63 @@ For additional context, refer to some of these links.
 - [Reference Architectures](https://cloudposse.com/) - Launch effortlessly with our turnkey reference architectures, built either by your team or ours.
 
 
+
+> [!TIP]
+> #### Use Terraform Reference Architectures for AWS
+>
+> Use Cloud Posse's ready-to-go [terraform architecture blueprints](https://cloudposse.com/reference-architecture/) for AWS to get up and running quickly.
+>
+> ✅ We build it together with your team.<br/>
+> ✅ Your team owns everything.<br/>
+> ✅ 100% Open Source and backed by fanatical support.<br/>
+>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-addon&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+> <details><summary>📚 <strong>Learn More</strong></summary>
+>
+> <br/>
+>
+> Cloud Posse is the leading [**DevOps Accelerator**](https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-addon&utm_content=commercial_support) for funded startups and enterprises.
+>
+> *Your team can operate like a pro today.*
+>
+> Ensure that your team succeeds by using Cloud Posse's proven process and turnkey blueprints. Plus, we stick around until you succeed.
+> #### Day-0:  Your Foundation for Success
+> - **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
+> - **Deployment Strategy.** Adopt a proven deployment strategy with GitHub Actions, enabling automated, repeatable, and reliable software releases.
+> - **Site Reliability Engineering.** Gain total visibility into your applications and services with Datadog, ensuring high availability and performance.
+> - **Security Baseline.** Establish a secure environment from the start, with built-in governance, accountability, and comprehensive audit logs, safeguarding your operations.
+> - **GitOps.** Empower your team to manage infrastructure changes confidently and efficiently through Pull Requests, leveraging the full power of GitHub Actions.
+>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-addon&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+>
+> #### Day-2: Your Operational Mastery
+> - **Training.** Equip your team with the knowledge and skills to confidently manage the infrastructure, ensuring long-term success and self-sufficiency.
+> - **Support.** Benefit from a seamless communication over Slack with our experts, ensuring you have the support you need, whenever you need it.
+> - **Troubleshooting.** Access expert assistance to quickly resolve any operational challenges, minimizing downtime and maintaining business continuity.
+> - **Code Reviews.** Enhance your team’s code quality with our expert feedback, fostering continuous improvement and collaboration.
+> - **Bug Fixes.** Rely on our team to troubleshoot and resolve any issues, ensuring your systems run smoothly.
+> - **Migration Assistance.** Accelerate your migration process with our dedicated support, minimizing disruption and speeding up time-to-value.
+> - **Customer Workshops.** Engage with our team in weekly workshops, gaining insights and strategies to continuously improve and innovate.
+>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-addon&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+> </details>
+
 ## ✨ Contributing
 
 This project is under active development, and we encourage contributions from our community.
+
+
+
 Many thanks to our outstanding contributors:
 
-<a href="https://github.com/cloudposse-terraform-components/template/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cloudposse-terraform-components/template&max=24" />
+<a href="https://github.com/cloudposse-terraform-components/aws-eks-addon/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse-terraform-components/aws-eks-addon&max=24" />
 </a>
 
-### 🐛 Bug Reports & Feature Requests
-
-Please use the [issue tracker](https://github.com/cloudposse-terraform-components/template/issues) to report any bugs or file feature requests.
-
-### 💻 Developing
-
-If you are interested in being a contributor and want to get involved in developing this project or help out with Cloud Posse's other projects, we would love to hear from you!
-Hit us up in [Slack](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=slack), in the `#cloudposse` channel.
+For 🐛 bug reports & feature requests, please use the [issue tracker](https://github.com/cloudposse-terraform-components/aws-eks-addon/issues).
 
 In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
- 1. Review our [Code of Conduct](https://github.com/cloudposse-terraform-components/template/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
+ 1. Review our [Code of Conduct](https://github.com/cloudposse-terraform-components/aws-eks-addon/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
  2. **Fork** the repo on GitHub
  3. **Clone** the project to your own machine
  4. **Commit** changes to your own branch
@@ -161,49 +196,17 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ### 🌎 Slack Community
 
-Join our [Open Source Community](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=slack) on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+Join our [Open Source Community](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-addon&utm_content=slack) on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
 ### 📰 Newsletter
 
-Sign up for [our newsletter](https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=newsletter) and join 3,000+ DevOps engineers, CTOs, and founders who get insider access to the latest DevOps trends, so you can always stay in the know.
+Sign up for [our newsletter](https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-addon&utm_content=newsletter) and join 3,000+ DevOps engineers, CTOs, and founders who get insider access to the latest DevOps trends, so you can always stay in the know.
 Dropped straight into your Inbox every week — and usually a 5-minute read.
 
-### 📆 Office Hours <a href="https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=office_hours"><img src="https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png" align="right" /></a>
+### 📆 Office Hours <a href="https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-addon&utm_content=office_hours"><img src="https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png" align="right" /></a>
 
-[Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
+[Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-addon&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
 It's **FREE** for everyone!
-
-## About
-
-This project is maintained by <a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=">Cloud Posse, LLC</a>.
-<a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content="><img src="https://cloudposse.com/logo-300x69.svg" align="right" /></a>
-
-We are a [**DevOps Accelerator**](https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support) for funded startups and enterprises.
-Use our ready-to-go terraform architecture blueprints for AWS to get up and running quickly.
-We build it with you. You own everything. Your team wins. Plus, we stick around until you succeed.
-
-<a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support"><img alt="Learn More" src="https://img.shields.io/badge/learn%20more-success.svg?style=for-the-badge"/></a>
-
-*Your team can operate like a pro today.*
-
-Ensure that your team succeeds by using our proven process and turnkey blueprints. Plus, we stick around until you succeed.
-
-<details>
-  <summary>📚 <strong>See What's Included</strong></summary>
-
-- **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
-- **Deployment Strategy.** You'll have a battle-tested deployment strategy using GitHub Actions that's automated and repeatable.
-- **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
-- **Security Baseline.** You'll have built-in governance with accountability and audit logs for all changes.
-- **GitOps.** You'll be able to operate your infrastructure via Pull Requests.
-- **Training.** You'll receive hands-on training so your team can operate what we build.
-- **Questions.** You'll have a direct line of communication between our teams via a Shared Slack channel.
-- **Troubleshooting.** You'll get help to triage when things aren't working.
-- **Code Reviews.** You'll receive constructive feedback on Pull Requests.
-- **Bug Fixes.** We'll rapidly work with you to fix any bugs in our projects.
-</details>
-
-<a href="https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_commercial_support_link"><img src="https://cloudposse.com/readme/commercial-support/img"/></a>
 ## License
 
 <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="License"></a>
@@ -238,10 +241,12 @@ under the License.
 ## Trademarks
 
 All other trademarks referenced herein are the property of their respective owners.
+
+
 ---
-Copyright © 2017-2024 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2025 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
-<a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
+<a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-addon&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
 
-<img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse-terraform-components/template?pixel&cs=github&cm=readme&an=template"/>
+<img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse-terraform-components/aws-eks-addon?pixel&cs=github&cm=readme&an=aws-eks-addon"/>

--- a/README.yaml
+++ b/README.yaml
@@ -1,23 +1,37 @@
-name: "template"
+name: "aws-eks-addon"
 
 # Canonical GitHub repo
-github_repo: "cloudposse-terraform-components/template"
+github_repo: "cloudposse-terraform-components/aws-eks-addon"
 
 # Short description of this project
 description: |-
-  Description of this component
+  This component is responsible for installing and managing addons for EKS clusters.
+
+  You may want to use this component rather than `var.addons` with `eks/cluster` to deploy addons that require additional
+  prerequisites or configuration before they can be installed. For example, if you need to install a priority class before
+  installing an addon, you can use this component to install the priority class first.
 
 usage: |-
-  **Stack Level**: Regional or Test47
+  **Stack Level**: Regional
 
-  Here's an example snippet for how to use this component.
-  
+  For example, to install the CloudWatch Observability addon for EKS:
+
   ```yaml
   components:
     terraform:
-      foo:
+      # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Observability-EKS-addon.html
+      eks/addon/cloudwatch:
+        metadata:
+          component: eks/addon
         vars:
-          enabled: true
+          addon_name: amazon-cloudwatch-observability
+          addon_version: "v2.5.0-eksbuild.1"
+          kubernetes_namespace: amazon-cloudwatch # this namespace is defined by the addon
+          resolve_conflicts_on_create: OVERWRITE
+          resolve_conflicts_on_update: OVERWRITE
+          priority_class_enabled: true
+          additional_policy_arns:
+            - "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
   ```
 
 include:
@@ -29,14 +43,14 @@ tags:
   - aws
   - components
   - terraform-components
-  - root
-  - geodesic
-  - reference-implementation
-  - reference-architecture
+  - eks
+  - addon
+  - kubernetes
+  - helm
 
 # Categories of this project
 categories:
-  - terraform-modules/root
+  - terraform-modules/eks
   - terraform-components
 
 # License of this project
@@ -45,8 +59,8 @@ license: "APACHE2"
 # Badges to display
 badges:
   - name: "Latest Release"
-    image: "https://img.shields.io/github/release/cloudposse-terraform-components/template.svg?style=for-the-badge"
-    url: "https://github.com/cloudposse-terraform-components/template/releases/latest"
+    image: "https://img.shields.io/github/release/cloudposse-terraform-components/aws-eks-addon.svg?style=for-the-badge"
+    url: "https://github.com/cloudposse-terraform-components/aws-eks-addon/releases/latest"
   - name: "Slack Community"
     image: "https://slack.cloudposse.com/for-the-badge.svg"
     url: "https://slack.cloudposse.com"

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,133 @@
+---
+tags:
+  - component/eks/addon
+  - layer/eks
+  - provider/aws
+  - provider/helm
+---
+
+# Component: `eks/addon`
+
+This component is responsible for installing and managing addons for EKS clusters.
+
+You may want to use this component rather than `var.addons` with `eks/cluster` to deploy addons that require additional
+prerequisites or configuration before they can be installed. For example, if you need to install a priority class before
+installing an addon, you can use this component to install the priority class first.
+
+## Usage
+
+**Stack Level**: Regional
+
+For example, to install the CloudWatch Observability addon for EKS:
+
+```yaml
+components:
+  terraform:
+    # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Observability-EKS-addon.html
+    eks/addon/cloudwatch:
+      metadata:
+        component: eks/addon
+      vars:
+        addon_name: amazon-cloudwatch-observability
+        addon_version: "v2.5.0-eksbuild.1"
+        kubernetes_namespace: amazon-cloudwatch # this namespace is defined by the addon
+        resolve_conflicts_on_create: OVERWRITE
+        resolve_conflicts_on_update: OVERWRITE
+        priority_class_enabled: true
+        additional_policy_arns:
+          - "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+```
+
+<!-- prettier-ignore-start -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.14.0, != 2.21.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.14.0, != 2.21.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_eks_iam_role"></a> [eks\_iam\_role](#module\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.1 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_eks_addon.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [kubernetes_priority_class.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/priority_class) | resource |
+| [aws_eks_cluster_auth.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_policy_arns"></a> [additional\_policy\_arns](#input\_additional\_policy\_arns) | Additional policy ARNs to attach to the EKS addon service account | `list(string)` | `[]` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_addon_name"></a> [addon\_name](#input\_addon\_name) | The name of the EKS addon | `string` | n/a | yes |
+| <a name="input_addon_version"></a> [addon\_version](#input\_addon\_version) | The version of the EKS addon | `string` | `null` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_configuration_values"></a> [configuration\_values](#input\_configuration\_values) | The configuration values for the EKS addon | `map(string)` | `{}` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
+| <a name="input_create_timeout"></a> [create\_timeout](#input\_create\_timeout) | The timeout to create the EKS addon | `string` | `"15m"` | no |
+| <a name="input_delete_timeout"></a> [delete\_timeout](#input\_delete\_timeout) | The timeout to delete the EKS addon | `string` | `"15m"` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the EKS component | `string` | `"eks/cluster"` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_helm_manifest_experiment_enabled"></a> [helm\_manifest\_experiment\_enabled](#input\_helm\_manifest\_experiment\_enabled) | Enable storing of the rendered manifest for helm\_release so the full diff of what is changing can been seen in the plan | `bool` | `false` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_kube_data_auth_enabled"></a> [kube\_data\_auth\_enabled](#input\_kube\_data\_auth\_enabled) | If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.<br/>Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`. | `bool` | `false` | no |
+| <a name="input_kube_exec_auth_aws_profile"></a> [kube\_exec\_auth\_aws\_profile](#input\_kube\_exec\_auth\_aws\_profile) | The AWS config profile for `aws eks get-token` to use | `string` | `""` | no |
+| <a name="input_kube_exec_auth_aws_profile_enabled"></a> [kube\_exec\_auth\_aws\_profile\_enabled](#input\_kube\_exec\_auth\_aws\_profile\_enabled) | If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token` | `bool` | `false` | no |
+| <a name="input_kube_exec_auth_enabled"></a> [kube\_exec\_auth\_enabled](#input\_kube\_exec\_auth\_enabled) | If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.<br/>Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`. | `bool` | `true` | no |
+| <a name="input_kube_exec_auth_role_arn"></a> [kube\_exec\_auth\_role\_arn](#input\_kube\_exec\_auth\_role\_arn) | The role ARN for `aws eks get-token` to use | `string` | `""` | no |
+| <a name="input_kube_exec_auth_role_arn_enabled"></a> [kube\_exec\_auth\_role\_arn\_enabled](#input\_kube\_exec\_auth\_role\_arn\_enabled) | If `true`, pass `kube_exec_auth_role_arn` as the role ARN to `aws eks get-token` | `bool` | `true` | no |
+| <a name="input_kubeconfig_context"></a> [kubeconfig\_context](#input\_kubeconfig\_context) | Context to choose from the Kubernetes config file.<br/>If supplied, `kubeconfig_context_format` will be ignored. | `string` | `""` | no |
+| <a name="input_kubeconfig_context_format"></a> [kubeconfig\_context\_format](#input\_kubeconfig\_context\_format) | A format string to use for creating the `kubectl` context name when<br/>`kubeconfig_file_enabled` is `true` and `kubeconfig_context` is not supplied.<br/>Must include a single `%s` which will be replaced with the cluster name. | `string` | `""` | no |
+| <a name="input_kubeconfig_exec_auth_api_version"></a> [kubeconfig\_exec\_auth\_api\_version](#input\_kubeconfig\_exec\_auth\_api\_version) | The Kubernetes API version of the credentials returned by the `exec` auth plugin | `string` | `"client.authentication.k8s.io/v1beta1"` | no |
+| <a name="input_kubeconfig_file"></a> [kubeconfig\_file](#input\_kubeconfig\_file) | The Kubernetes provider `config_path` setting to use when `kubeconfig_file_enabled` is `true` | `string` | `""` | no |
+| <a name="input_kubeconfig_file_enabled"></a> [kubeconfig\_file\_enabled](#input\_kubeconfig\_file\_enabled) | If `true`, configure the Kubernetes provider with `kubeconfig_file` and use that kubeconfig file for authenticating to the EKS cluster | `bool` | `false` | no |
+| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | The Kubernetes namespace for the EKS addon | `string` | `"kube-system"` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_priority_class_enabled"></a> [priority\_class\_enabled](#input\_priority\_class\_enabled) | Whether to enable the priority class for the EKS addon | `bool` | `false` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_resolve_conflicts_on_create"></a> [resolve\_conflicts\_on\_create](#input\_resolve\_conflicts\_on\_create) | How to resolve conflicts on addon creation | `string` | `null` | no |
+| <a name="input_resolve_conflicts_on_update"></a> [resolve\_conflicts\_on\_update](#input\_resolve\_conflicts\_on\_update) | How to resolve conflicts on addon update | `string` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_update_timeout"></a> [update\_timeout](#input\_update\_timeout) | The timeout to update the EKS addon | `string` | `"15m"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_mock"></a> [mock](#output\_mock) | Mock output example for the Cloud Posse Terraform component template |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- prettier-ignore-end -->
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,8 +1,62 @@
 locals {
   enabled = module.this.enabled
+
+  priority_class_enabled = local.enabled && var.priority_class_enabled
+  priority_class_name    = module.this.id
 }
 
+resource "aws_eks_addon" "this" {
+  count = local.enabled ? 1 : 0
 
+  addon_name                  = var.addon_name
+  addon_version               = var.addon_version
+  configuration_values        = jsonencode(var.configuration_values)
+  resolve_conflicts_on_create = var.resolve_conflicts_on_create
+  resolve_conflicts_on_update = var.resolve_conflicts_on_update
 
+  cluster_name             = one(module.eks.outputs[*].eks_cluster_id)
+  service_account_role_arn = module.eks_iam_role.service_account_role_arn
 
+  tags = module.this.tags
 
+  timeouts {
+    create = var.create_timeout
+    update = var.update_timeout
+    delete = var.delete_timeout
+  }
+
+  depends_on = [module.eks_iam_role, kubernetes_priority_class.this]
+}
+
+module "eks_iam_role" {
+  source  = "cloudposse/eks-iam-role/aws"
+  version = "2.1.1"
+
+  enabled = local.enabled
+
+  eks_cluster_oidc_issuer_url = module.eks.outputs.eks_cluster_identity_oidc_issuer
+
+  service_account_name      = module.this.id
+  service_account_namespace = var.kubernetes_namespace
+
+  context = module.this.context
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each = local.enabled ? toset(var.additional_policy_arns) : toset([])
+
+  role       = module.eks_iam_role.service_account_role_name
+  policy_arn = each.value
+}
+
+resource "kubernetes_priority_class" "this" {
+  count = local.priority_class_enabled ? 1 : 0
+
+  metadata {
+    name = local.priority_class_name
+  }
+
+  value          = 1000000
+  global_default = false
+  description    = "Priority class for the ${module.this.id} EKS addon"
+}

--- a/src/provider-helm.tf
+++ b/src/provider-helm.tf
@@ -1,0 +1,201 @@
+##################
+#
+# This file is a drop-in to provide a helm provider.
+#
+# It depends on 2 standard Cloud Posse data source modules to be already
+# defined in the same component:
+#
+#   1. module.iam_roles to provide the AWS profile or Role ARN to use to access the cluster
+#   2. module.eks to provide the EKS cluster information
+#
+# All the following variables are just about configuring the Kubernetes provider
+# to be able to modify EKS cluster. The reason there are so many options is
+# because at various times, each one of them has had problems, so we give you a choice.
+#
+# The reason there are so many "enabled" inputs rather than automatically
+# detecting whether or not they are enabled based on the value of the input
+# is that any logic based on input values requires the values to be known during
+# the "plan" phase of Terraform, and often they are not, which causes problems.
+#
+variable "kubeconfig_file_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, configure the Kubernetes provider with `kubeconfig_file` and use that kubeconfig file for authenticating to the EKS cluster"
+  nullable    = false
+}
+
+variable "kubeconfig_file" {
+  type        = string
+  default     = ""
+  description = "The Kubernetes provider `config_path` setting to use when `kubeconfig_file_enabled` is `true`"
+  nullable    = false
+}
+
+variable "kubeconfig_context" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    Context to choose from the Kubernetes config file.
+    If supplied, `kubeconfig_context_format` will be ignored.
+    EOT
+  nullable    = false
+}
+
+variable "kubeconfig_context_format" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    A format string to use for creating the `kubectl` context name when
+    `kubeconfig_file_enabled` is `true` and `kubeconfig_context` is not supplied.
+    Must include a single `%s` which will be replaced with the cluster name.
+    EOT
+  nullable    = false
+}
+
+variable "kube_data_auth_enabled" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.
+    Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`.
+    EOT
+  nullable    = false
+}
+
+variable "kube_exec_auth_enabled" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.
+    Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`.
+    EOT
+  nullable    = false
+}
+
+variable "kube_exec_auth_role_arn" {
+  type        = string
+  default     = ""
+  description = "The role ARN for `aws eks get-token` to use"
+  nullable    = false
+}
+
+variable "kube_exec_auth_role_arn_enabled" {
+  type        = bool
+  default     = true
+  description = "If `true`, pass `kube_exec_auth_role_arn` as the role ARN to `aws eks get-token`"
+  nullable    = false
+}
+
+variable "kube_exec_auth_aws_profile" {
+  type        = string
+  default     = ""
+  description = "The AWS config profile for `aws eks get-token` to use"
+  nullable    = false
+}
+
+variable "kube_exec_auth_aws_profile_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token`"
+  nullable    = false
+}
+
+variable "kubeconfig_exec_auth_api_version" {
+  type        = string
+  default     = "client.authentication.k8s.io/v1beta1"
+  description = "The Kubernetes API version of the credentials returned by the `exec` auth plugin"
+  nullable    = false
+}
+
+variable "helm_manifest_experiment_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable storing of the rendered manifest for helm_release so the full diff of what is changing can been seen in the plan"
+  nullable    = false
+}
+
+locals {
+  kubeconfig_file_enabled = var.kubeconfig_file_enabled
+  kubeconfig_file         = local.kubeconfig_file_enabled ? var.kubeconfig_file : ""
+  kubeconfig_context = !local.kubeconfig_file_enabled ? "" : (
+    length(var.kubeconfig_context) != 0 ? var.kubeconfig_context : (
+      length(var.kubeconfig_context_format) != 0 ? format(var.kubeconfig_context_format, local.eks_cluster_id) : ""
+    )
+  )
+
+  kube_exec_auth_enabled = local.kubeconfig_file_enabled ? false : var.kube_exec_auth_enabled
+  kube_data_auth_enabled = local.kube_exec_auth_enabled ? false : var.kube_data_auth_enabled
+
+  # Eventually we might try to get this from an environment variable
+  kubeconfig_exec_auth_api_version = var.kubeconfig_exec_auth_api_version
+
+  exec_profile = local.kube_exec_auth_enabled && var.kube_exec_auth_aws_profile_enabled ? [
+    "--profile", var.kube_exec_auth_aws_profile
+  ] : []
+
+  kube_exec_auth_role_arn = coalesce(var.kube_exec_auth_role_arn, module.iam_roles.terraform_role_arn)
+  exec_role = local.kube_exec_auth_enabled && var.kube_exec_auth_role_arn_enabled ? [
+    "--role-arn", local.kube_exec_auth_role_arn
+  ] : []
+
+  # Provide dummy configuration for the case where the EKS cluster is not available.
+  certificate_authority_data = local.kubeconfig_file_enabled ? null : try(module.eks.outputs.eks_cluster_certificate_authority_data, null)
+  cluster_ca_certificate     = local.kubeconfig_file_enabled ? null : try(base64decode(local.certificate_authority_data), null)
+  # Use coalesce+try to handle both the case where the output is missing and the case where it is empty.
+  eks_cluster_id       = coalesce(try(module.eks.outputs.eks_cluster_id, ""), "missing")
+  eks_cluster_endpoint = local.kubeconfig_file_enabled ? null : try(module.eks.outputs.eks_cluster_endpoint, "")
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  count = local.kube_data_auth_enabled ? 1 : 0
+  name  = local.eks_cluster_id
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.eks_cluster_endpoint
+    cluster_ca_certificate = local.cluster_ca_certificate
+    token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
+    # It is too confusing to allow the Kubernetes provider to use environment variables to set authentication
+    # in this module because we have so many options, so we override environment variables like `KUBE_CONFIG_PATH`
+    # in all cases. People can still use environment variables by setting TF_VAR_kubeconfig_file.
+    config_path    = local.kubeconfig_file
+    config_context = local.kubeconfig_context
+
+    dynamic "exec" {
+      for_each = local.kube_exec_auth_enabled && local.certificate_authority_data != null ? ["exec"] : []
+      content {
+        api_version = local.kubeconfig_exec_auth_api_version
+        command     = "aws"
+        args = concat(local.exec_profile, [
+          "eks", "get-token", "--cluster-name", local.eks_cluster_id
+        ], local.exec_role)
+      }
+    }
+  }
+  experiments {
+    manifest = var.helm_manifest_experiment_enabled && module.this.enabled
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.eks_cluster_endpoint
+  cluster_ca_certificate = local.cluster_ca_certificate
+  token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
+  # It is too confusing to allow the Kubernetes provider to use environment variables to set authentication
+  # in this module because we have so many options, so we override environment variables like `KUBE_CONFIG_PATH`
+  # in all cases. People can still use environment variables by setting TF_VAR_kubeconfig_file.
+  config_path    = local.kubeconfig_file
+  config_context = local.kubeconfig_context
+
+  dynamic "exec" {
+    for_each = local.kube_exec_auth_enabled && local.certificate_authority_data != null ? ["exec"] : []
+    content {
+      api_version = local.kubeconfig_exec_auth_api_version
+      command     = "aws"
+      args = concat(local.exec_profile, [
+        "eks", "get-token", "--cluster-name", local.eks_cluster_id
+      ], local.exec_role)
+    }
+  }
+}

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = var.region
+
+  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
+  profile = module.iam_roles.terraform_profile_name
+
+  dynamic "assume_role" {
+    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
+    for_each = compact([module.iam_roles.terraform_role_arn])
+    content {
+      role_arn = assume_role.value
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../../account-map/modules/iam-roles"
+  context = module.this.context
+}

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,0 +1,14 @@
+variable "eks_component_name" {
+  description = "The name of the EKS component"
+  type        = string
+  default     = "eks/cluster"
+}
+
+module "eks" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component = var.eks_component_name
+
+  context = module.this.context
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -1,0 +1,69 @@
+variable "region" {
+  description = "AWS Region"
+  type        = string
+}
+
+variable "addon_name" {
+  type        = string
+  description = "The name of the EKS addon"
+}
+
+variable "addon_version" {
+  type        = string
+  description = "The version of the EKS addon"
+  default     = null
+}
+
+variable "configuration_values" {
+  type        = map(string)
+  description = "The configuration values for the EKS addon"
+  default     = {}
+}
+
+variable "kubernetes_namespace" {
+  type        = string
+  description = "The Kubernetes namespace for the EKS addon"
+  default     = "kube-system"
+}
+
+variable "resolve_conflicts_on_create" {
+  type        = string
+  description = "How to resolve conflicts on addon creation"
+  default     = null
+}
+
+variable "resolve_conflicts_on_update" {
+  type        = string
+  description = "How to resolve conflicts on addon update"
+  default     = null
+}
+
+variable "create_timeout" {
+  type        = string
+  description = "The timeout to create the EKS addon"
+  default     = "15m"
+}
+
+variable "update_timeout" {
+  type        = string
+  description = "The timeout to update the EKS addon"
+  default     = "15m"
+}
+
+variable "delete_timeout" {
+  type        = string
+  description = "The timeout to delete the EKS addon"
+  default     = "15m"
+}
+
+variable "additional_policy_arns" {
+  type        = list(string)
+  description = "Additional policy ARNs to attach to the EKS addon service account"
+  default     = []
+}
+
+variable "priority_class_enabled" {
+  type        = bool
+  description = "Whether to enable the priority class for the EKS addon"
+  default     = false
+}

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -1,5 +1,18 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  required_providers {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.14.0, != 2.21.0"
+    }
+  }
 }

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -12,7 +12,7 @@ type ComponentSuite struct {
 }
 
 func (s *ComponentSuite) TestBasic() {
-	const component = "example/basic"
+	const component = "eks/addon/cloudwatch"
 	const stack = "default-test"
 	const awsRegion = "us-east-2"
 
@@ -23,9 +23,8 @@ func (s *ComponentSuite) TestBasic() {
 	s.DriftTest(component, stack, nil)
 }
 
-
 func (s *ComponentSuite) TestEnabledFlag() {
-	const component = "example/disabled"
+	const component = "eks/addon/cloudwatch"
 	const stack = "default-test"
 	s.VerifyEnabledFlag(component, stack, nil)
 }

--- a/test/fixtures/stacks/catalog/usecase/basic.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic.yaml
@@ -1,7 +1,15 @@
 components:
   terraform:
-    example/basic:
+    eks/addon/cloudwatch:
       metadata:
-        component: target
+        component: eks/addon
       vars:
         enabled: true
+        addon_name: amazon-cloudwatch-observability
+        addon_version: "v2.5.0-eksbuild.1"
+        kubernetes_namespace: amazon-cloudwatch
+        resolve_conflicts_on_create: OVERWRITE
+        resolve_conflicts_on_update: OVERWRITE
+        priority_class_enabled: true
+        additional_policy_arns:
+          - "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"

--- a/test/fixtures/stacks/catalog/usecase/disabled.yaml
+++ b/test/fixtures/stacks/catalog/usecase/disabled.yaml
@@ -1,7 +1,7 @@
 components:
   terraform:
-    example/disabled:
+    eks/addon/cloudwatch:
       metadata:
-        component: target
+        component: eks/addon
       vars:
         enabled: false


### PR DESCRIPTION
## what
- Upstream the `eks/addon` component

## why
- This component is responsible for installing and managing addons for EKS clusters.
- You may want to use this component rather than `var.addons` with `eks/cluster` to deploy addons that require additional prerequisites or configuration before they can be installed. For example, if you need to install a priority class before installing an addon, you can use this component to install the priority class first.

## references
- https://github.com/cloudposse-terraform-components/aws-kinesis-firehose-stream/pull/4
- https://github.com/cloudposse-terraform-components/aws-eks-cloudwatch/pull/3
