### PR TITLE
Rollback providers constraints

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 7.0.0"
+      version = ">= 4.9.0, < 6.0.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "< 4.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## what
* Rollback providers' constraints

## why
* The component had `published: false` property, so it bypassed the requirements constraints and got some wrong PRs merged

## references
* #24 
* #22 