### PR TITLE
Use atmos instead of makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ aws-assumed-role/
 *.iml
 .direnv
 .envrc
+.atmos
 
 # Compiled and auto-generated files
 # Note that the leading "**/" appears necessary for Docker even if not for Git

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
--include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
-
-all: init readme
-
-test::
-	@echo "🚀 Starting tests..."
-	./test/run.sh
-	@echo "✅ All tests passed."

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -1,0 +1,11 @@
+# Atmos Configuration — powered by https://atmos.tools
+#
+# This configuration enables centralized, DRY, and consistent project scaffolding using Atmos.
+#
+# Included features:
+# - Organizational custom commands: https://atmos.tools/core-concepts/custom-commands
+# - Automated README generation: https://atmos.tools/cli/commands/docs/generate
+#
+# Import shared configuration used by all modules
+import:
+  - https://raw.githubusercontent.com/cloudposse-terraform-components/.github/refs/heads/main/.github/atmos/terraform-component.yaml


### PR DESCRIPTION
## what
* Use atmos instead of makefile

## why
* build-harness deprecated. Use atmos instead 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced centralized project configuration to standardize component settings, enable custom commands, and automate README generation for a smoother developer experience.

- Chores
  - Updated ignore rules to exclude tool-generated directories, reducing noise in commits.
  - Removed legacy build and test scaffolding to streamline tooling and simplify local setup.

- Tests
  - Retired outdated local test target; no impact on runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->